### PR TITLE
Fixing null DateTimes returning current date

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -513,7 +513,13 @@ abstract class AbstractModel extends Model implements ModelInterface
      */
     protected function formatTimeAttribute($name)
     {
-        $date_time = new DateTime($this->read_attribute($name));
+        $read_date_time = $this->read_attribute($name);
+
+        if (empty($read_date_time)) {
+            return null;
+        }
+
+        $date_time = new DateTime($read_date_time);
 
         return (string) $date_time->format(static::DATE_TIME_FORMAT);
     }


### PR DESCRIPTION
In the old function, if the date passed was null or an empty string we would just return the current date.
