### PR TITLE
Bugfix - fuzzyFind Strictness

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/FuzzyFindTrait.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/FuzzyFindTrait.php
@@ -22,9 +22,10 @@ trait FuzzyFindTrait
 {
 
     /**
-     * Get by ID, or just return the instance itself
+     * Get strictly, or just return the instance itself
      *
      * @see FuzzyFindInterface::fuzzyFind()
+     * @see AbstractModel::findStrict()
      * @param mixed $reference
      * @static
      * @access public
@@ -37,7 +38,7 @@ trait FuzzyFindTrait
             return $reference;
         } else {
             // Try and get our model by ID
-            return static::find($reference);
+            return static::findStrict($reference);
         }
     }
 }


### PR DESCRIPTION
Making the FuzzyFindTrait more strict, because passing in NULL was yielding an empty array... #thanksActiveRecord

Its also how we expect to use it, always. Ooooops.

I've already tested it in "our main project" (that's not open source, so shouldn't necessarily be mentioned here), and it twerks. :+1: 
