### PR TITLE
Feature: fuzzyId

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/FuzzyKeyInterface.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/FuzzyKeyInterface.php
@@ -30,7 +30,7 @@ interface FuzzyKeyInterface extends FuzzyFindInterface
      *   matches the type of the key than the reference is directly returned.
      * @static
      * @access public
-     * @return int
+     * @return mixed
      */
     public static function fuzzyKey($reference);
 }

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/FuzzyKeyTrait.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/FuzzyKeyTrait.php
@@ -33,7 +33,7 @@ trait FuzzyKeyTrait
      *   matches the type of the key than the reference is directly returned.
      * @static
      * @access public
-     * @return int
+     * @return mixed
      */
     public static function fuzzyKey($reference)
     {


### PR DESCRIPTION
This has been talked about a few times in the past. In the case where we're given a reference object, it would be useful to be able to efficiently get the "id" of the reference without making unneeded DB calls.

eg. 

``` PHP
    public function getAuthor($book_ref)
    {
        $book = Account::fuzzyFind($book_ref);

        $author = Author::find_by_book_id($book->id);
        // OR
        $author = $book->author

        return $author;
    }
```

The above example will do what's needed, but it makes two calls to the DB. If the $book_ref is the book's ID, then we don't need to look up the book object:

``` PHP
    public function getAuthor($book_ref)
    {
        $id = is_int($book_ref) ? $book_ref : Account::fuzzyFind($book_ref)->id;
        $author = Author::find_by_book_id($id);
        return $author;
    }
```

This PR adds in a convenient method to reduce the amount of repetitive code in an app:

``` PHP
    public function getAuthor($book_ref)
    {
        $id = Account::fuzzyId($book_ref);
        $author = Author::find_by_book_id($id);
        return $author;
    }
```
