### PR TITLE
Bugfix - Paged result invalid state

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/PagedResult.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/PagedResult.php
@@ -244,21 +244,21 @@ class PagedResult
      */
     public function setPagingProperties(array $paging_properties)
     {
-        $mass_settable_properties = array(
-            'order',
-            'limit',
-            'offset',
+        $mass_settable_keys = array(
+            'order' => null,
+            'limit' => null,
+            'offset' => null,
         );
 
         // Drop the keys we don't want
         $props = array_intersect_key(
             $paging_properties,
-            array_flip($mass_settable_properties)
+            $mass_settable_keys
         );
 
         // Make sure there are no "unset" keys
         $props = array_merge(
-            array_flip($mass_settable_properties),
+            $mass_settable_keys,
             $props
         );
 


### PR DESCRIPTION
This PR fixes a possible invalid state of the PagedResult object and invalid default values.
- Previously, the `setPage()` method would allow for the `page` attribute to have a `0` or negative value. This has been fixed to only allow non-empty positive integers
- The `setPagingProperties()` method did some array flipping magic on a bare array, causing possible default values of properties to be set from the default indexes of an array (0, 1, 2, etc)
- Finally, the default value of the constructor's `paging_options` was null, but the value was immediately passed to a strictly typed method which would fatally error due to an optional argument.... #oops. This has now been fixed and will error out to the library user earlier (within their own code) due to the new constructor type-hints.
