### PR TITLE
Bugfix - Updating the magical model isset method to check defined relationships

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -714,6 +714,24 @@ abstract class AbstractModel extends Model implements ModelInterface
     }
 
     /**
+     * Determines if an attribute or relationship exists for this Model
+     *
+     * @see \ActiveRecord\Model::__isset()
+     * @param string $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        if (parent::__isset($name)) {
+            return true;
+        }
+
+        $table = static::table();
+
+        return $table->has_relationship($name);
+    }
+
+    /**
      * Function to format time object attributes
      *
      * @access protected


### PR DESCRIPTION
I'm not sure if this is intended behavior, but it doesn't make sense to me to have a magical getter that will pickup a defined model relationship and not have the magical isset reflect that behavior.

This PR now makes the Model's `__isset()` function check for defined relationships as well.
