### PR TITLE
Feature - Readonly freeze

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -106,6 +106,14 @@ abstract class AbstractModel extends Model implements ModelInterface
      */
     protected static $default_values = array();
 
+    /**
+     * Flag denoting the "freeze" state of the readonly property
+     *
+     * @var boolean
+     * @access private
+     */
+    private $readonly_frozen = false;
+
 
     /**
      * Methods
@@ -640,6 +648,38 @@ abstract class AbstractModel extends Model implements ModelInterface
     public static function indexModelArrayByKey(array $models)
     {
         return static::indexModelArrayByAttribute($models);
+    }
+
+    /**
+     * freezeAsReadonly
+     *
+     * @access public
+     * @return void
+     */
+    public function freezeAsReadonly()
+    {
+        // Set as readonly
+        $this->readonly(true);
+
+        // Freeze the attribute
+        $this->readonly_frozen = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param boolean $readonly Set to true to put the model into readonly mode
+     * @access public
+     * @return void
+     */
+    public function readonly($readonly = true)
+    {
+        // Don't allow them to change the readonly state if its frozen
+        if ($this->readonly_frozen) {
+            return;
+        }
+
+        parent::readonly($readonly);
     }
 
     /**

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -673,7 +673,7 @@ abstract class AbstractModel extends Model implements ModelInterface
     }
 
     /**
-     * freezeAsReadonly
+     * Put the model in a readonly state permanently
      *
      * @access public
      * @return void

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -120,6 +120,28 @@ abstract class AbstractModel extends Model implements ModelInterface
      */
 
     /**
+     * Create a new readonly model that can't be saved or changed
+     *
+     * This is a very convenient method for using models as true data/value-objects
+     * without having to worry about another service breaking contract and persisting
+     * the data represented by the model
+     *
+     * @see static::__construct()
+     * @see static::freezeAsReadonly()
+     * @param array $attributes
+     * @param mixed $guard_attributes
+     * @return AbstractModel
+     */
+    public static function createAsFrozenReadonly(array $attributes = array(), $guard_attributes = true)
+    {
+        $model = new static($attributes, $guard_attributes);
+
+        $model->freezeAsReadonly();
+
+        return $model;
+    }
+
+    /**
      * Constructor
      *
      * @see \ActiveRecord\Model::__construct()

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -683,6 +683,19 @@ abstract class AbstractModel extends Model implements ModelInterface
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * This is a PSR-2 valid, camel-case style method alias
+     *
+     * @access public
+     * @return boolean
+     */
+    public function isReadonly()
+    {
+        return $this->is_readonly();
+    }
+
+    /**
      * Get an attribute of the object
      *
      * @see \ActiveRecord\Model::__get()


### PR DESCRIPTION
There have been a few times working with AR models that I wish I could use them more as true data models (and not some entire, crazy ORM). Especially with some of the more recent features I've been working on in an application, I've wanted to have a value object without having to duplicate the models for some non-persistent object.

Well, this PR introduces exactly that!

This PR introduces a new `freezeAsReadonly()` method that forces the model to switch over to a non-persistent mode that can't be reversed through normal means. Simple as that. So now you can pass around data models without worrying that some misbehaving service would try to persist the data through the AR methods.

:smiley: 