### PR TITLE
Feature - Assert valid

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -718,6 +718,29 @@ abstract class AbstractModel extends Model implements ModelInterface
     }
 
     /**
+     * Assert that a model is valid
+     *
+     * This will check if a model is valid, and will throw a validation exception
+     * if the model is found to have any validation errors
+     *
+     * @param bool $always_validate Run validations, even if we already know that the model is invalid
+     * @access public
+     * @return void
+     */
+    public function assertValid($always_validate = true)
+    {
+        $valid = $this->errors->is_empty();
+
+        if ($valid || $always_validate) {
+            $valid = $this->is_valid();
+        }
+
+        if (!$valid) {
+            throw ActiveRecordValidationException::createFromValidatedModel($this);
+        }
+    }
+
+    /**
      * Get an attribute of the object
      *
      * @see \ActiveRecord\Model::__get()

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -725,6 +725,7 @@ abstract class AbstractModel extends Model implements ModelInterface
      *
      * @param bool $always_validate Run validations, even if we already know that the model is invalid
      * @access public
+     * @throws ActiveRecordValidationException If the model has any validation errors
      * @return void
      */
     public function assertValid($always_validate = true)


### PR DESCRIPTION
This PR adds a new method on the `AbstractModel` to assert that a model is valid, and throw an exception otherwise. Its really just a very convenient method to have.

... I can't believe we didn't make this already.