### PR TITLE
Bugfix - assertValid null reference

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -730,7 +730,7 @@ abstract class AbstractModel extends Model implements ModelInterface
      */
     public function assertValid($always_validate = true)
     {
-        $valid = $this->errors->is_empty();
+        $valid = (null !== $this->errors && $this->errors->is_empty());
 
         if ($valid || $always_validate) {
             $valid = $this->is_valid();


### PR DESCRIPTION
This PR makes sure to check that the `errors` property isn't null before using it.
Whoops.