### PR TITLE
Feature - Updating composer to use forked activerecord dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,15 @@
          "homepage": "http://brianmuse.com/"
       }
    ],
+  "repositories": [
+    {
+      "type": "git",
+      "url":  "git@github.com:onemightyroar/php-activerecord.git"
+    }
+  ],
    "require": {
       "php": ">=5.3.0",
-      "php-activerecord/php-activerecord": "1.1.x"
+      "onemightyroar/php-activerecord": "~1.1.0"
    },
    "suggest": {
       "onemightyroar/predis-toolkit": "To make use of the AbstractRedisIntegrationModel"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   ],
    "require": {
       "php": ">=5.3.0",
-      "onemightyroar/php-activerecord": "~1.1.0"
+      "robinpowered/php-activerecord": "~1.1.0"
    },
    "suggest": {
       "onemightyroar/predis-toolkit": "To make use of the AbstractRedisIntegrationModel"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "repositories": [
     {
       "type": "git",
-      "url":  "git@github.com:onemightyroar/php-activerecord.git"
+      "url":  "git@github.com:robinpowered/php-activerecord.git"
     }
   ],
    "require": {


### PR DESCRIPTION
Times, they are a changing.

I've made a new branch called `omr-dev`. This branch will make use of the forked [`robinpowered/php-activerecord`](https://github.com/robinpowered/php-activerecord) repo so that we may begin to actually override some of the functionality of ActiveRecord since we all know nobody is committing to the original repo anymore.

The `robinpowered/php-activerecord` is set to the `v1.2.0` release with a composer name update on top.

We can start to do new releases off of the `omr-dev` branch (that is, if we ever really have to update this repo again).