### PR TITLE
Feature - Cache interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+###### Composer External Libraries/Files ######
+/vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
       "doctrine/cache": "^1.4"
    },
    "suggest": {
-      "onemightyroar/predis-toolkit": "To make use of the AbstractRedisIntegrationModel"
+      "onemightyroar/predis-toolkit": "To make use of the AbstractRedisIntegrationModel",
+      "doctrine/cache": "To easily implement ActiveRecord caching and the included adapter/translator"
    },
    "autoload": {
       "psr-0": { "OneMightyRoar\\PHP_ActiveRecord_Components\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
       "php": ">=5.3.0",
       "php-activerecord/php-activerecord": "1.1.x"
    },
+   "require-dev": {
+      "doctrine/cache": "^1.4"
+   },
    "suggest": {
       "onemightyroar/predis-toolkit": "To make use of the AbstractRedisIntegrationModel"
    },

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * PHP-ActiveRecord-Components
+ *
+ * Useful common components for a php-activerecord based project
+ *
+ * @copyright   2013 One Mighty Roar
+ * @link        http://onemightyroar.com
+ */
+
+namespace OneMightyRoar\PHP_ActiveRecord_Components\Cache\Adapter;
+
+use Doctrine\Common\Cache\CacheProvider;
+use OneMightyRoar\PHP_ActiveRecord_Components\Cache\CacheAdapterInterface;
+
+/**
+ * DoctrineCacheAdapter
+ *
+ * An adapter to translate a Doctrine {@see CacheProvider} into a PHP-ActiveRecord
+ * compatible cache adapter, through the {@see CacheAdapterInterface}
+ *
+ * @package OneMightyRoar\PHP_ActiveRecord_Components\Cache\Adapter
+ */
+class DoctrineCacheAdapter implements CacheAdapterInterface
+{
+
+    /**
+     * Constants
+     */
+
+    /**
+     * The default value for the option of whether or not to flush the namespace
+     * instead of the entire cache for flush operations
+     *
+     * @type bool
+     */
+    const FLUSH_NAMESPACE_DEFAULT = false;
+
+
+    /**
+     * Properties
+     */
+
+    /**
+     * The Doctrine cache provider to be adapted
+     *
+     * @type CacheProvider
+     */
+    private $adapted_provider;
+
+    /**
+     * Whether or not to flush the namespace instead of the entire cache when
+     * committing a cache flush
+     *
+     * @type bool
+     */
+    private $flush_namespace = false;
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * Constructor
+     *
+     * @param CacheProvider $cache_provider The Doctrine cache provider to be adapted
+     */
+    public function __construct(CacheProvider $cache_provider, $flush_namespace = self::FLUSH_NAMESPACE_DEFAULT)
+    {
+        $this->adapted_provider = $cache_provider;
+        $this->flush_namespace = (bool) $flush_namespace;
+    }
+
+    /**
+     * Get the value of flush_namespace
+     *
+     * @access public
+     * @return bool
+     */
+    public function getFlushNamespace()
+    {
+        return $this->flush_namespace;
+    }
+
+    /**
+     * Set the value of flush_namespace
+     *
+     * @param bool $flush_namespace
+     * @access public
+     * @return $this
+     */
+    public function setFlushNamespace($flush_namespace)
+    {
+        $this->flush_namespace = (bool) $flush_namespace;
+
+        return $this;
+    }
+
+    /**
+     * Read a value from the cache at the specified key
+     *
+     * @param string $key The unique cache key used to locate/identify the contents to read
+     * @access public
+     * @return mixed The cached value
+     */
+    public function read($key)
+    {
+        return $this->adapted_provider->fetch($key);
+    }
+
+    /**
+     * Write a value to the cache at the specified key with an optional TTL
+     *
+     * @param string $key The unique cache key used to designate/identify the stored location
+     * @param mixed $value The value to cache
+     * @param int $ttl An optional time-to-live in seconds, for future-expiring cache data
+     * @access public
+     * @return void
+     */
+    public function write($key, $value, $ttl = null)
+    {
+        return $this->adapted_provider->save($key, $value, $ttl);
+    }
+
+    /**
+     * Flush all cache entries
+     *
+     * @access public
+     * @return void
+     */
+    public function flush()
+    {
+        if ($this->flush_namespace) {
+            $this->adapted_provider->deleteAll();
+        } else {
+            $this->adapted_provider->flushAll();
+        }
+    }
+}

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
@@ -120,7 +120,7 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
      */
     public function write($key, $value, $ttl = null)
     {
-        return $this->adapted_provider->save($key, $value, $ttl);
+        $this->adapted_provider->save($key, $value, $ttl);
     }
 
     /**

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
@@ -54,7 +54,7 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
      *
      * @type bool
      */
-    private $flush_namespace = false;
+    private $flush_namespace = self::FLUSH_NAMESPACE_DEFAULT;
 
 
     /**
@@ -65,6 +65,7 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
      * Constructor
      *
      * @param CacheProvider $cache_provider The Doctrine cache provider to be adapted
+     * @param bool $flush_namespace Whether or not to flush the namespace (vs full) when commiting a cache flush
      */
     public function __construct(CacheProvider $cache_provider, $flush_namespace = self::FLUSH_NAMESPACE_DEFAULT)
     {

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
@@ -32,7 +32,7 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
      * The default value for the option of whether or not to flush the namespace
      * instead of the entire cache for flush operations
      *
-     * @type bool
+     * @const bool
      */
     const FLUSH_NAMESPACE_DEFAULT = false;
 
@@ -44,7 +44,8 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
     /**
      * The Doctrine cache provider to be adapted
      *
-     * @type CacheProvider
+     * @var CacheProvider
+     * @access private
      */
     private $adapted_provider;
 
@@ -52,7 +53,8 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
      * Whether or not to flush the namespace instead of the entire cache when
      * committing a cache flush
      *
-     * @type bool
+     * @var bool
+     * @access protected
      */
     protected $flush_namespace = self::FLUSH_NAMESPACE_DEFAULT;
 

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
@@ -54,7 +54,7 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
      *
      * @type bool
      */
-    private $flush_namespace = self::FLUSH_NAMESPACE_DEFAULT;
+    protected $flush_namespace = self::FLUSH_NAMESPACE_DEFAULT;
 
 
     /**
@@ -82,20 +82,6 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
     public function getFlushNamespace()
     {
         return $this->flush_namespace;
-    }
-
-    /**
-     * Set the value of flush_namespace
-     *
-     * @param bool $flush_namespace
-     * @access public
-     * @return $this
-     */
-    public function setFlushNamespace($flush_namespace)
-    {
-        $this->flush_namespace = (bool) $flush_namespace;
-
-        return $this;
     }
 
     /**

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/Adapter/DoctrineCacheAdapter.php
@@ -74,6 +74,17 @@ class DoctrineCacheAdapter implements CacheAdapterInterface
     }
 
     /**
+     * Get the underlying adapted Doctrine cache provider
+     *
+     * @access public
+     * @return CacheProvider
+     */
+    public function getAdaptedCache()
+    {
+        return $this->adapted_provider;
+    }
+
+    /**
      * Get the value of flush_namespace
      *
      * @access public

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheAdapterInterface.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheAdapterInterface.php
@@ -11,13 +11,13 @@
 namespace OneMightyRoar\PHP_ActiveRecord_Components\Cache;
 
 /**
- * CacheInterface
+ * CacheAdapterInterface
  *
  * An interface for the {@link \ActiveRecord\Cache} adapter
  *
  * @package OneMightyRoar\PHP_ActiveRecord_Components\Cache
  */
-interface CacheInterface
+interface CacheAdapterInterface
 {
 
     /**

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInitializer.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInitializer.php
@@ -63,7 +63,7 @@ class CacheInitializer
 
         Cache::$options = [
             static::OPTION_KEY_NAMESPACE => (string) $namespace,
-            static::OPTION_KEY_EXPIRE => (int) $default_ttl ?: -1,
+            static::OPTION_KEY_EXPIRE => (int) $default_ttl,
         ];
     }
 }

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInitializer.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInitializer.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PHP-ActiveRecord-Components
+ *
+ * Useful common components for a php-activerecord based project
+ *
+ * @copyright   2013 One Mighty Roar
+ * @link        http://onemightyroar.com
+ */
+
+namespace OneMightyRoar\PHP_ActiveRecord_Components\Cache;
+
+use ActiveRecord\Cache;
+
+/**
+ * CacheInitializer
+ *
+ * Eases the setup of the PHP-ActiveRecord cache through a psuedo-factory,
+ * allowing more type-safe initialization and compatibility
+ *
+ * @package OneMightyRoar\PHP_ActiveRecord_Components\Cache
+ */
+class CacheInitializer
+{
+
+    /**
+     * Constants
+     */
+
+    /**
+     * The option map key for the "namespace" option
+     *
+     * @type string
+     */
+    const OPTION_KEY_NAMESPACE = 'namespace';
+
+    /**
+     * The option map key for the "expire" option
+     *
+     * @type string
+     */
+    const OPTION_KEY_EXPIRE = 'expire';
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * Statically initializes the global Cache adapter
+     *
+     * While the static global state is far from ideal, this provides pure compatibility
+     * with AR's use of the cache implementation without a deep refactor or BC break
+     *
+     * @param CacheAdapterInterface $adapter The adapter to use for the cache
+     * @param string $namespace An optional namespace to prefix all cache keys with
+     * @param int $default_ttl The default expiry/TTL, in seconds, for each cache entry
+     * @return void
+     */
+    public static function init(CacheAdapterInterface $adapter, $namespace = null, $default_ttl = null)
+    {
+        Cache::$adapter = $adapter;
+
+        Cache::$options = [
+            static::OPTION_KEY_NAMESPACE => (string) $namespace,
+            static::OPTION_KEY_EXPIRE => (int) $default_ttl ?: -1,
+        ];
+    }
+}

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInitializer.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInitializer.php
@@ -30,14 +30,14 @@ class CacheInitializer
     /**
      * The option map key for the "namespace" option
      *
-     * @type string
+     * @const string
      */
     const OPTION_KEY_NAMESPACE = 'namespace';
 
     /**
      * The option map key for the "expire" option
      *
-     * @type string
+     * @const string
      */
     const OPTION_KEY_EXPIRE = 'expire';
 
@@ -55,6 +55,8 @@ class CacheInitializer
      * @param CacheAdapterInterface $adapter The adapter to use for the cache
      * @param string $namespace An optional namespace to prefix all cache keys with
      * @param int $default_ttl The default expiry/TTL, in seconds, for each cache entry
+     * @static
+     * @access public
      * @return void
      */
     public static function init(CacheAdapterInterface $adapter, $namespace = null, $default_ttl = null)

--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInterface.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/Cache/CacheInterface.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHP-ActiveRecord-Components
+ *
+ * Useful common components for a php-activerecord based project
+ *
+ * @copyright   2013 One Mighty Roar
+ * @link        http://onemightyroar.com
+ */
+
+namespace OneMightyRoar\PHP_ActiveRecord_Components\Cache;
+
+/**
+ * CacheInterface
+ *
+ * An interface for the {@link \ActiveRecord\Cache} adapter
+ *
+ * @package OneMightyRoar\PHP_ActiveRecord_Components\Cache
+ */
+interface CacheInterface
+{
+
+    /**
+     * Read a value from the cache at the specified key
+     *
+     * @param string $key The unique cache key used to locate/identify the contents to read
+     * @access public
+     * @return mixed The cached value
+     */
+    public function read($key);
+
+    /**
+     * Write a value to the cache at the specified key with an optional TTL
+     *
+     * @param string $key The unique cache key used to designate/identify the stored location
+     * @param mixed $value The value to cache
+     * @param int $ttl An optional time-to-live in seconds, for future-expiring cache data
+     * @access public
+     * @return void
+     */
+    public function write($key, $value, $ttl = null);
+
+    /**
+     * Flush all cache entries
+     *
+     * @access public
+     * @return void
+     */
+    public function flush();
+}


### PR DESCRIPTION
This PR introduces an interface to the [internal PHP-ActiveRecord cache adapter][phpactiverecord-cache-adapter] to allow for strong typing and documentation of the internal cache API.

Obviously, in order to work as intended, the interface was designed to match the current AR cache adapter invocation arguments.

Also, in order to make using the Cache as painless as possible, I've included 2 other classes:

1. A `DoctrineCacheAdapter` to allow for a simple adaptation between Doctrine's **very** popular and common cache providers and the new interface here.
2. A `CacheInitializer` static initializer class to simplify the setup of the AR cache through the new interfaces.

Ideally AR would have had an interface defined for the cache adapter originally, but it doesn't. If one is ever defined, we can update this by including another adapter of sorts for BC.



[phpactiverecord-cache-adapter]: https://github.com/jpfuentes2/php-activerecord/blob/b2ed6fc64ef35c88fd30d71091df0d0765719901/lib/Cache.php#L13