### PR TITLE
Feature - Wildcard Escaping

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -674,6 +674,27 @@ abstract class AbstractModel extends Model implements ModelInterface
     }
 
     /**
+     * Escape a query parameter value containing wildcards
+     *
+     * Useful (and important) for when using a `LIKE` query, as not-escaping
+     * those queries would allow for a wildcard to be entered by a user and
+     * access every result.
+     *
+     * @param string $parameter_value The value to escape
+     * @static
+     * @access public
+     * @return string
+     */
+    public static function escapeParameterWildcards($parameter_value)
+    {
+        return str_replace(
+            ['%', '_'],
+            ['\%', '\_'],
+            $parameter_value
+        );
+    }
+
+    /**
      * Put the model in a readonly state permanently
      *
      * @access public


### PR DESCRIPTION
This PR simply adds a new method to escape a query parameter's value that contains wildcards.

This is useful (and important) for when using a `LIKE` query, as not-escaping those queries would allow for a wildcard to be entered by a user and access every result.

Example usage:

```php
// PROBLEMATIC query!! WARNING!!
$options['conditions'] = [
    'name LIKE ?',
    '%' . $search_string . '%',
];

// Good query :)
$options['conditions'] = [
    'name LIKE ?',
    '%' . ExampleModel::escapeParameterWildcards($search_string) . '%',
];

ExampleModel::all($options);
```

Thanks to @mcos for the idea!

More info:

- https://dev.mysql.com/doc/refman/5.5/en/string-literals.html