### PR TITLE
Bugfix - Invalid paging parameters

### DIFF
--- a/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
+++ b/src/OneMightyRoar/PHP_ActiveRecord_Components/AbstractModel.php
@@ -579,11 +579,15 @@ abstract class AbstractModel extends Model implements ModelInterface
             $offset = (($page - 1) * $per_page) + static::DEFAULT_OFFSET;
         }
 
+        // Normalize our values to force a valid range
+        $limit = (int) $limit >= 1 ? $limit : static::DEFAULT_LIMIT;
+        $offset = (int) $offset > 0 ? $offset : static::DEFAULT_OFFSET;
+
         // Define and return our query options array
         return array(
             'order'  => $order,
-            'limit'  => $limit,
-            'offset' => $offset,
+            'limit'  => (int) $limit,
+            'offset' => (int) $offset,
         );
     }
 


### PR DESCRIPTION
This PR makes a quick change to the ~~awful~~ (:trollface:) `AbstractModel::buildPagingOptions` method to make sure that it normalizes the `limit` and `offset` values to a **safe** value by checking for constraints that would otherwise cause MySQL to either error or return a dangerously large result.

It was discussed whether or not this should enforce the values by throwing an exception for values outside of the acceptable range, but we decided instead to silently coerce the values instead.